### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -2,12 +2,12 @@
 :spring_data_rest: current
 :spring_data_commons: current
 :spring_boot_version: 2.1.3.RELEASE
-:Component: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Component.html
-:Controller: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html
-:DispatcherServlet: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/servlet/DispatcherServlet.html
-:SpringApplication: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
-:ResponseBody: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/bind/annotation/ResponseBody.html
-:EnableAutoConfiguration: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/autoconfigure/EnableAutoConfiguration.html
+:Component: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Component.html
+:Controller: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html
+:DispatcherServlet: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/servlet/DispatcherServlet.html
+:SpringApplication: https://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
+:ResponseBody: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/bind/annotation/ResponseBody.html
+:EnableAutoConfiguration: https://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/autoconfigure/EnableAutoConfiguration.html
 :toc:
 :icons: font
 :source-highlighter: prettify
@@ -17,7 +17,7 @@ This guide walks you through the process of creating an application that accesse
 
 == What you'll build
 
-You'll build a Spring application that let's you create and retrieve `Person` objects stored in a http://www.mongodb.org/[MongoDB] link:/understanding/NoSQL[NoSQL] database using Spring Data REST. Spring Data REST takes the features of http://projects.spring.io/spring-hateoas[Spring HATEOAS] and http://projects.spring.io/spring-data-mongodb[Spring Data MongoDB] and combines them together automatically.
+You'll build a Spring application that let's you create and retrieve `Person` objects stored in a https://www.mongodb.org/[MongoDB] link:/understanding/NoSQL[NoSQL] database using Spring Data REST. Spring Data REST takes the features of https://projects.spring.io/spring-hateoas[Spring HATEOAS] and https://projects.spring.io/spring-data-mongodb[Spring Data MongoDB] and combines them together automatically.
 
 NOTE: Spring Data REST also supports link:/guides/gs/accessing-data-rest[Spring Data JPA], link:/guides/gs/accessing-gemfire-data-rest[Spring Data Gemfire] and link:/guides/gs/accessing-neo4j-data-rest[Spring Data Neo4j] as backend data stores, but those are not part of this guide.
 
@@ -48,7 +48,7 @@ On a Mac OS X machine with homebrew, just do this:
 brew install mongodb
 ```
 
-More installation options are found at http://docs.mongodb.org/manual/installation/.
+More installation options are found at https://docs.mongodb.org/manual/installation/.
 
 After installing it, you need to launch the mongo daemon.
 
@@ -81,15 +81,15 @@ Next you need to create a simple repository.
 include::complete/src/main/java/hello/PersonRepository.java[]
 ----
 
-This repository is an interface and will allow you to perform various operations involving `Person` objects. It gets these operations by extending `MongoRepository`, which in turn extends the http://docs.spring.io/spring-data/commons/docs/{spring_data_commons}/api/org/springframework/data/repository/PagingAndSortingRepository.html[PagingAndSortingRepository] interface defined in Spring Data Commons.
+This repository is an interface and will allow you to perform various operations involving `Person` objects. It gets these operations by extending `MongoRepository`, which in turn extends the https://docs.spring.io/spring-data/commons/docs/{spring_data_commons}/api/org/springframework/data/repository/PagingAndSortingRepository.html[PagingAndSortingRepository] interface defined in Spring Data Commons.
 
-At runtime, Spring Data REST will create an implementation of this interface automatically. Then it will use the http://docs.spring.io/spring-data/rest/docs/{spring_data_rest}/api/org/springframework/data/rest/core/annotation/RepositoryRestResource.html[@RepositoryRestResource] annotation to direct Spring MVC to create RESTful endpoints at `/people`.
+At runtime, Spring Data REST will create an implementation of this interface automatically. Then it will use the https://docs.spring.io/spring-data/rest/docs/{spring_data_rest}/api/org/springframework/data/rest/core/annotation/RepositoryRestResource.html[@RepositoryRestResource] annotation to direct Spring MVC to create RESTful endpoints at `/people`.
 
 NOTE: `@RepositoryRestResource` is not required for a repository to be exported. It is only used to change the export details, such as using `/people` instead of the default value of `/persons`.
 
 Here you have also defined a custom query to retrieve a list of `Person` objects based on the lastName. You'll see how to invoke it further down in this guide.
 
-NOTE: Spring Boot by default attempts to connect to a locally hosted instance of MongoDB. Read the http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-mongodb[reference docs] for details on pointing your app to an instance of MongoDB hosted elsewhere.
+NOTE: Spring Boot by default attempts to connect to a locally hosted instance of MongoDB. Read the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-mongodb[reference docs] for details on pointing your app to an instance of MongoDB hosted elsewhere.
 
 == Make the application executable
 
@@ -157,7 +157,7 @@ $ curl http://localhost:8080/people
 
 There are currently no elements and hence no pages. Time to create a new `Person`!
 
-NOTE: If you run this guide multiple times, there may be left over data. Refer to the http://docs.mongodb.org/manual/reference/mongo-shell/[MongoDB shell quick reference] to find commands to find and drop your database if you need a fresh start.
+NOTE: If you run this guide multiple times, there may be left over data. Refer to the https://docs.mongodb.org/manual/reference/mongo-shell/[MongoDB shell quick reference] to find commands to find and drop your database if you need a fresh start.
 
 ```
 $ curl -i -X POST -H "Content-Type:application/json" -d "{  \"firstName\" : \"Frodo\",  \"lastName\" : \"Baggins\" }" http://localhost:8080/people
@@ -209,7 +209,7 @@ $ curl http://localhost:8080/people
 }
 ```
 
-The **persons** object contains a list with Frodo. Notice how it includes a **self** link. Spring Data REST also uses http://www.atteo.org/2011/12/12/Evo-Inflector.html[Evo Inflector] to pluralize the name of the entity for groupings.
+The **persons** object contains a list with Frodo. Notice how it includes a **self** link. Spring Data REST also uses https://www.atteo.org/2011/12/12/Evo-Inflector.html[Evo Inflector] to pluralize the name of the entity for groupings.
 
 You can query directly for the individual record:
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://stateless.co/hal_specification.html (200) with 1 occurrences could not be migrated:  
   ([https](https://stateless.co/hal_specification.html) result SSLHandshakeException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/ ([https](https://docs.spring.io/spring-boot/docs/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring/docs/ with 4 occurrences migrated to:  
  https://docs.spring.io/spring/docs/ ([https](https://docs.spring.io/spring/docs/) result 200).
* [ ] http://www.atteo.org/2011/12/12/Evo-Inflector.html with 1 occurrences migrated to:  
  https://www.atteo.org/2011/12/12/Evo-Inflector.html ([https](https://www.atteo.org/2011/12/12/Evo-Inflector.html) result 200).
* [ ] http://docs.mongodb.org/manual/installation/ with 1 occurrences migrated to:  
  https://docs.mongodb.org/manual/installation/ ([https](https://docs.mongodb.org/manual/installation/) result 301).
* [ ] http://docs.mongodb.org/manual/reference/mongo-shell/ with 1 occurrences migrated to:  
  https://docs.mongodb.org/manual/reference/mongo-shell/ ([https](https://docs.mongodb.org/manual/reference/mongo-shell/) result 301).
* [ ] http://docs.spring.io/spring-data/commons/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/commons/docs/ ([https](https://docs.spring.io/spring-data/commons/docs/) result 301).
* [ ] http://docs.spring.io/spring-data/rest/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/rest/docs/ ([https](https://docs.spring.io/spring-data/rest/docs/) result 301).
* [ ] http://projects.spring.io/spring-data-mongodb with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-mongodb ([https](https://projects.spring.io/spring-data-mongodb) result 301).
* [ ] http://projects.spring.io/spring-hateoas with 1 occurrences migrated to:  
  https://projects.spring.io/spring-hateoas ([https](https://projects.spring.io/spring-hateoas) result 301).
* [ ] http://www.mongodb.org/ with 1 occurrences migrated to:  
  https://www.mongodb.org/ ([https](https://www.mongodb.org/) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080 with 1 occurrences
* http://localhost:8080/people with 9 occurrences
* http://localhost:8080/people/53149b8e3004990b1af9f229 with 12 occurrences
* http://localhost:8080/people/search with 4 occurrences
* http://localhost:8080/people/search/findByLastName with 1 occurrences
* http://localhost:8080/people/search/findByLastName?name=Baggins with 1 occurrences